### PR TITLE
HPA: propose to use default scale configuration (targetCPUUtilizationPercentage: 70)

### DIFF
--- a/_infra/values.yaml
+++ b/_infra/values.yaml
@@ -2,7 +2,7 @@
 autoscaling:
   minReplicas: 3
   maxReplicas: 5
-  targetCPUUtilizationPercentage: 90
+  targetCPUUtilizationPercentage: 70
 
 image:
   repository: eu.gcr.io/my-registry/istio-redirector


### PR DESCRIPTION
The following documentation presents some strong defaults for HPA
https://blablacar.atlassian.net/wiki/spaces/CD/pages/2271379457/Stateless+right+sizing+of+your+application+CPU+Memory+HPA#HorizontalPodAutoscaler-(HPA)-Guidelines

If your workload uses scaling based on CPU => 70% threshold should be enforced (`.spec.targetCPUUtilizationPercentage: 70`) and other values are strongly NOT recommended, because:
- higher threshold could lead to CPU issues on the hosting node and impact on neighbor workloads so it can’t be decided alone (consult Foundations !)
- lower introduces more waste and the problems it solves can be fixed by using smaller pods

This PR proposes to rely on this 70% cpu utilization.
If for any reason, your workload should not use this settings, let us know :)