### PR TITLE
[CINF-2192]add commonLabels value and add labels on all resources

### DIFF
--- a/_infra/Chart.yaml
+++ b/_infra/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v1
 name: istio-redirector
-version: 0.0.7
+version: 0.0.8

--- a/_infra/templates/_helpers.tpl
+++ b/_infra/templates/_helpers.tpl
@@ -30,3 +30,18 @@ Create chart name and version as used by the chart label.
 {{- define "istio-redirector.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Labels that should be added on each resource
+*/}}
+{{- define "labels" -}}
+app.kubernetes.io/name: {{ include "istio-redirector.name" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+helm.sh/chart: {{ include "istio-redirector.chart" . }}
+app: {{ .Release.Name }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
+{{- end -}}

--- a/_infra/templates/cluster-role-binding.yaml
+++ b/_infra/templates/cluster-role-binding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}
   labels:
-    app: {{ .Release.Name }}
+{{- include "labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/_infra/templates/cluster-role.yaml
+++ b/_infra/templates/cluster-role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}
   labels:
-    app: {{ .Release.Name }}
+{{- include "labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - networking.istio.io

--- a/_infra/templates/configmap.yaml
+++ b/_infra/templates/configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}
+  labels:
+{{- include "labels" . | nindent 4 }}
 data:
   config.yaml: |+
     {{- tpl (.Files.Get "files/config.yaml") . | nindent 4 }}

--- a/_infra/templates/deployment.yaml
+++ b/_infra/templates/deployment.yaml
@@ -3,14 +3,10 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}
   labels:
-    app.kubernetes.io/name: {{ include "istio-redirector.name" . }}
-    helm.sh/chart: {{ include "istio-redirector.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app: {{ .Release.Name }}
 {{- with .Values.deployment.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
+{{- include "labels" . | nindent 4 }}
 spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.autoscaling.minReplicas }}
@@ -27,15 +23,11 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "istio-redirector.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app: {{ .Release.Name }}
 {{- with .Values.pod.labels }}
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- include "labels" . | nindent 8 }}
       annotations:
-        json_logs: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 {{- with .Values.pod.annotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/_infra/templates/destinationrule.yaml
+++ b/_infra/templates/destinationrule.yaml
@@ -4,7 +4,7 @@ kind: DestinationRule
 metadata:
   name: {{ .Release.Name }}
   labels:
-    app: {{ .Release.Name }}
+{{- include "labels" . | nindent 4 }}
 spec:
   host: {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
 {{- if .Values.destinationRule.trafficPolicy }}

--- a/_infra/templates/hpa.yaml
+++ b/_infra/templates/hpa.yaml
@@ -5,7 +5,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}
   labels:
-    app: {{ .Release.Name }}
+{{- include "labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/_infra/templates/pdb.yaml
+++ b/_infra/templates/pdb.yaml
@@ -3,9 +3,11 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ .Release.Name }}
   labels:
-    app: {{ .Release.Name }}
+{{- include "labels" . | nindent 4 }}
 spec:
   maxUnavailable: {{ .Values.pdb }}
   selector:
     matchLabels:
+      app.kubernetes.io/name: {{ include "istio-redirector.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       app: {{ .Release.Name }}

--- a/_infra/templates/service.yaml
+++ b/_infra/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}
   labels:
-    app: {{ .Release.Name }}
+{{- include "labels" . | nindent 4 }}
   annotations:
 {{- with .Values.service.annotations }}
 {{ toYaml . | indent 4 }}
@@ -15,4 +15,7 @@ spec:
       protocol: TCP
       name: http
   selector:
+    app.kubernetes.io/name: {{ include "istio-redirector.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ .Release.Name }}
+

--- a/_infra/templates/serviceaccount.yaml
+++ b/_infra/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ .Release.Name }}
+{{- include "labels" . | nindent 4 }}
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 automountServiceAccountToken: true

--- a/_infra/templates/servicemonitor.yaml
+++ b/_infra/templates/servicemonitor.yaml
@@ -4,11 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ .Release.Name }}
   labels:
-    app.kubernetes.io/name: {{ include "istio-redirector.name" . }}
-    helm.sh/chart: {{ include "istio-redirector.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app: {{ .Release.Name }}
+{{- include "labels" . | nindent 4 }}
 spec:
   jobLabel: app
   endpoints:

--- a/_infra/templates/virtualservice.yaml
+++ b/_infra/templates/virtualservice.yaml
@@ -4,7 +4,7 @@ kind: VirtualService
 metadata:
   name: {{ .Release.Name }}
   labels:
-    app: {{ .Release.Name }}
+{{- include "labels" . | nindent 4 }}
 spec:
   hosts:
   -  {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/_infra/values.yaml
+++ b/_infra/values.yaml
@@ -70,6 +70,8 @@ volumeMounts:
     subPath: config.yaml
     readOnly: true
 
+commonLabels: {}
+
 deployment:
   labels: {}
 


### PR DESCRIPTION
Creation of a new commonLabels value to add labels to all resources.
Use a labels helper to place a set of labels on chart resources.

Labels applied on all resources
app.kubernetes.io/name: {{ include "istio-redirector.name" . }}
app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
app.kubernetes.io/managed-by: {{ .Release.Service }}
app.kubernetes.io/instance: {{ .Release.Name }}
helm.sh/chart: {{ include "istio-redirector.chart" . }}
app: {{ .Release.Name }}